### PR TITLE
Button Released Bug

### DIFF
--- a/robotnik_pad/include/robotnik_pad/button.h
+++ b/robotnik_pad/include/robotnik_pad/button.h
@@ -27,16 +27,15 @@ public:
     is_pressed_ = value;
   }
 
-  int isPressed()
+  int isPressed() const
   {
     return is_pressed_;
   }
 
-  bool isReleased()
+  bool isReleased() const
   {
-    bool b = is_released_;
-    is_released_ = false;
-    return b;
+    return is_released_;
+  }
   }
 };
 

--- a/robotnik_pad/include/robotnik_pad/button.h
+++ b/robotnik_pad/include/robotnik_pad/button.h
@@ -36,6 +36,11 @@ public:
   {
     return is_released_;
   }
+
+  void updateStateIfButtonHasBeenReleased()
+  {
+    if (is_released_)
+      is_released_ = false;
   }
 };
 

--- a/robotnik_pad/include/robotnik_pad/generic_pad_plugin.h
+++ b/robotnik_pad/include/robotnik_pad/generic_pad_plugin.h
@@ -15,7 +15,7 @@ public:
 
 public:
   virtual void initialize(const ros::NodeHandle& nh, const std::string& plugin_ns) = 0;
-  virtual void execute(std::vector<Button>& buttons, std::vector<float>& axes) = 0;
+  virtual void execute(const std::vector<Button>& buttons, std::vector<float>& axes) = 0;
   virtual ~GenericPadPlugin()
   {
   }

--- a/robotnik_pad/src/robotnik_pad.cpp
+++ b/robotnik_pad/src/robotnik_pad.cpp
@@ -113,6 +113,11 @@ void RobotnikPad::readyState()
   {
     plugin->execute(buttons_, axes_);
   }
+
+  for (auto& button : buttons_)
+  {
+    button.updateStateIfButtonHasBeenReleased();
+  }
 }
 
 void RobotnikPad::emergencyState()

--- a/robotnik_pad_plugins/include/robotnik_pad_plugins/elevator_plugin.h
+++ b/robotnik_pad_plugins/include/robotnik_pad_plugins/elevator_plugin.h
@@ -1,8 +1,8 @@
 #ifndef PAD_PLUGIN_ELEVATOR_H_
 #define PAD_PLUGIN_ELEVATOR_H_
 
-#include <robotnik_pad/generic_pad_plugin.h>
 #include <robotnik_msgs/SetElevator.h>
+#include <robotnik_pad/generic_pad_plugin.h>
 
 namespace pad_plugins
 {
@@ -13,7 +13,7 @@ public:
   ~PadPluginElevator();
 
   virtual void initialize(const ros::NodeHandle &nh, const std::string &plugin_ns);
-  virtual void execute(std::vector<Button> &buttons, std::vector<float> &axes);
+  virtual void execute(const std::vector<Button> &buttons, std::vector<float> &axes);
 
 protected:
   int button_dead_man_;
@@ -22,5 +22,5 @@ protected:
   std::string elevator_service_name_;
   ros::ServiceClient set_elevator_client_;
 };
-} // namespace pad_plugins
-#endif // PAD_PLUGIN_ELEVATOR_H_
+}  // namespace pad_plugins
+#endif  // PAD_PLUGIN_ELEVATOR_H_

--- a/robotnik_pad_plugins/include/robotnik_pad_plugins/movement_plugin.h
+++ b/robotnik_pad_plugins/include/robotnik_pad_plugins/movement_plugin.h
@@ -21,7 +21,7 @@ public:
   ~PadPluginMovement();
 
   virtual void initialize(const ros::NodeHandle& nh, const std::string& plugin_ns);
-  virtual void execute(std::vector<Button>& buttons, std::vector<float>& axes);
+  virtual void execute(const std::vector<Button>& buttons, std::vector<float>& axes);
 
 protected:
   int button_dead_man_, axis_linear_x_, axis_linear_y_, axis_angular_z_, button_kinematic_mode_;

--- a/robotnik_pad_plugins/src/elevator_plugin.cpp
+++ b/robotnik_pad_plugins/src/elevator_plugin.cpp
@@ -24,7 +24,7 @@ void PadPluginElevator::initialize(const ros::NodeHandle &nh, const std::string 
   set_elevator_client_ = nh_.serviceClient<robotnik_msgs::SetElevator>("/rb1_base/robotnik_base_control/set_elevator");
 }
 
-void PadPluginElevator::execute(std::vector<Button> &buttons, std::vector<float> &axes)
+void PadPluginElevator::execute(const std::vector<Button> &buttons, std::vector<float> &axes)
 {
   if (buttons[button_dead_man_].isPressed())
   {
@@ -48,4 +48,4 @@ void PadPluginElevator::execute(std::vector<Button> &buttons, std::vector<float>
   }
 }
 
-} // namespace pad_plugins
+}  // namespace pad_plugins

--- a/robotnik_pad_plugins/src/movement_plugin.cpp
+++ b/robotnik_pad_plugins/src/movement_plugin.cpp
@@ -50,7 +50,7 @@ void PadPluginMovement::initialize(const ros::NodeHandle& nh, const std::string&
   kinematic_mode_ = Differential;
 }
 
-void PadPluginMovement::execute(std::vector<Button>& buttons, std::vector<float>& axes)
+void PadPluginMovement::execute(const std::vector<Button>& buttons, std::vector<float>& axes)
 {
   if (buttons[button_dead_man_].isPressed())
   {


### PR DESCRIPTION
## Problem
There is a bug when you execute more than one plugin for your pad. The function `execute` whitin `generic_pad_plugin.h` receives a reference to a vector of buttons where this vector is being updated by the function `isReleased()` from the class `Button`. This was causing to the plugins the inability to have an special case when the button was released. 

## Solution
The `execute` function now receives a `const` value so we make sure that the reference is not being updated in that function. Besides, an explicit request to update the state of the button has been added after every plugin has read the same button value.
