### PR TITLE
Ackermann mode

### DIFF
--- a/robotnik_pad/config/robotnik_pad_plugins_ackermann_ps4.yaml
+++ b/robotnik_pad/config/robotnik_pad_plugins_ackermann_ps4.yaml
@@ -1,0 +1,29 @@
+plugins:
+  - Movement
+  - Elevator
+
+pad:
+  type: ps4
+  num_of_buttons: 14
+  num_of_axes: 14
+
+Movement:
+  type: robotnik_pad_plugins/Movement
+  max_linear_speed: 1.5
+  cmd_topic_vel: pad_teleop/cmd_vel
+  wheel_base: 1.375
+  config:
+    button_deadman: 5
+    axis_linear_x: 1
+    axis_linear_y: 0
+    axis_angular_z: 2
+    button_speed_up: 3
+    button_speed_down: 1
+    button_kinematic_mode: 7
+
+Elevator:
+  type: robotnik_pad_plugins/Elevator
+  elevator_service_name: robotnik_base_control/set_elevator
+  config:
+    deadman: 5
+    axis_elevator: 10

--- a/robotnik_pad_plugins/CMakeLists.txt
+++ b/robotnik_pad_plugins/CMakeLists.txt
@@ -31,6 +31,7 @@ include_directories(
 add_library(robotnik_pad_plugins
   src/movement_plugin.cpp
   src/elevator_plugin.cpp
+  src/ackermann_movement_plugin.cpp
 )
 
 add_dependencies(robotnik_pad_plugins ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})

--- a/robotnik_pad_plugins/include/robotnik_pad_plugins/ackermann_movement_plugin.h
+++ b/robotnik_pad_plugins/include/robotnik_pad_plugins/ackermann_movement_plugin.h
@@ -1,0 +1,50 @@
+#ifndef PAD_PLUGIN_ACKERMANN_MOVEMENT_H_
+#define PAD_PLUGIN_ACKERMANN_MOVEMENT_H_
+
+#include <ackermann_msgs/AckermannDrive.h>
+#include <robotnik_pad/generic_pad_plugin.h>
+#include <robotnik_pad_msgs/MovementStatus.h>
+
+namespace pad_plugins
+{
+class PadPluginAckermannMovement : public GenericPadPlugin
+{
+public:
+  // Probably this should be stablish in generic_pad_plugin
+  enum KinematicMode
+  {
+    Differential = 0,
+    Omnidirectional = 1
+  };
+
+  PadPluginAckermannMovement();
+  ~PadPluginAckermannMovement();
+
+  virtual void initialize(const ros::NodeHandle& nh, const std::string& plugin_ns);
+  virtual void execute(std::vector<Button>& buttons, std::vector<float>& axes);
+
+protected:
+  int button_dead_man_, axis_linear_x_, axis_linear_y_, axis_angular_z_, button_kinematic_mode_;
+  int button_speed_up_, button_speed_down_;
+  double max_linear_speed_, max_angular_speed_;
+  std::string cmd_topic_vel_;
+
+  ros::Publisher ackermann_pub_, pad_status_pub_;
+
+  robotnik_pad_msgs::MovementStatus movement_status_msg_;
+  //! current velocity level used to compute the target velocity
+  double current_velocity_level_;
+  //! max velocity level allowed (Normally 1.0)
+  double max_velocity_level_;
+  //! min velocity level allowed (Normally 0.1 -> the 10% of max speed level)
+  double min_velocity_level_;
+  //! defines how much you can increase/decrease the max_velocity_level (Normally 0.1)
+  double velocity_level_step_;
+  ackermann_msgs::AckermannDrive cmd_ackermann_;
+  int kinematic_mode_;
+
+protected:
+  std::string kinematicModeToStr(int kinematic_mode);
+};
+}  // namespace pad_plugins
+#endif  // PAD_PLUGIN_ELEVATOR_H_

--- a/robotnik_pad_plugins/include/robotnik_pad_plugins/ackermann_movement_plugin.h
+++ b/robotnik_pad_plugins/include/robotnik_pad_plugins/ackermann_movement_plugin.h
@@ -10,12 +10,6 @@ namespace pad_plugins
 class PadPluginAckermannMovement : public GenericPadPlugin
 {
 public:
-  // Probably this should be stablish in generic_pad_plugin
-  enum KinematicMode
-  {
-    Differential = 0,
-    Omnidirectional = 1
-  };
 
   PadPluginAckermannMovement();
   ~PadPluginAckermannMovement();
@@ -41,10 +35,7 @@ protected:
   //! defines how much you can increase/decrease the max_velocity_level (Normally 0.1)
   double velocity_level_step_;
   ackermann_msgs::AckermannDrive cmd_ackermann_;
-  int kinematic_mode_;
-
-protected:
-  std::string kinematicModeToStr(int kinematic_mode);
+  
 };
 }  // namespace pad_plugins
 #endif  // PAD_PLUGIN_ELEVATOR_H_

--- a/robotnik_pad_plugins/include/robotnik_pad_plugins/movement_plugin.h
+++ b/robotnik_pad_plugins/include/robotnik_pad_plugins/movement_plugin.h
@@ -5,17 +5,23 @@
 #include <robotnik_pad/generic_pad_plugin.h>
 #include <robotnik_pad_msgs/MovementStatus.h>
 
+namespace KinematicModes
+{
+  enum KinematicMode
+  {
+      Differential = 0,
+      Omnidirectional = 1,
+  };
+}
+
+typedef KinematicModes::KinematicMode KinematicMode;
+
 namespace pad_plugins
 {
 class PadPluginMovement : public GenericPadPlugin
 {
 public:
   // Probably this should be stablish in generic_pad_plugin
-  enum KinematicMode
-  {
-    Differential = 0,
-    Omnidirectional = 1
-  };
 
   PadPluginMovement();
   ~PadPluginMovement();

--- a/robotnik_pad_plugins/include/robotnik_pad_plugins/movement_plugin.h
+++ b/robotnik_pad_plugins/include/robotnik_pad_plugins/movement_plugin.h
@@ -11,6 +11,7 @@ namespace KinematicModes
   {
       Differential = 0,
       Omnidirectional = 1,
+      Ackermann = 2
   };
 }
 
@@ -48,7 +49,8 @@ protected:
   double velocity_level_step_;
   geometry_msgs::Twist cmd_twist_;
   int kinematic_mode_;
-
+  //! used in ackermann mode
+  double wheel_base_;
 protected:
   std::string kinematicModeToStr(int kinematic_mode);
 };

--- a/robotnik_pad_plugins/robotnik_pad_pluginlib.xml
+++ b/robotnik_pad_plugins/robotnik_pad_pluginlib.xml
@@ -5,4 +5,7 @@
     <class name="robotnik_pad_plugins/Elevator" type="pad_plugins::PadPluginElevator" base_class_type="pad_plugins::GenericPadPlugin">
         <description>This is the Pad elevator plugin.</description>
     </class>
+    <class name="robotnik_pad_plugins/AckermannMovement" type="pad_plugins::PadPluginAckermannMovement" base_class_type="pad_plugins::GenericPadPlugin">
+        <description>This is the Pad movement plugin with ackermann msgs.</description>
+    </class>
 </library>

--- a/robotnik_pad_plugins/src/ackermann_movement_plugin.cpp
+++ b/robotnik_pad_plugins/src/ackermann_movement_plugin.cpp
@@ -1,0 +1,145 @@
+#include <robotnik_pad_plugins/ackermann_movement_plugin.h>
+
+namespace pad_plugins
+{
+PadPluginAckermannMovement::PadPluginAckermannMovement()
+{
+}
+
+PadPluginAckermannMovement::~PadPluginAckermannMovement()
+{
+}
+
+
+void PadPluginAckermannMovement::initialize(const ros::NodeHandle& nh, const std::string& plugin_ns)
+{
+  bool required = true;
+  pnh_ = ros::NodeHandle(nh, plugin_ns);
+  nh_ = ros::NodeHandle();
+  button_dead_man_ = 5;
+  readParam(pnh_, "config/button_deadman", button_dead_man_, button_dead_man_, required);
+  axis_linear_x_ = 1;
+  readParam(pnh_, "config/axis_linear_x", axis_linear_x_, axis_linear_x_, required);
+  axis_linear_y_ = 0;
+  readParam(pnh_, "config/axis_linear_y", axis_linear_y_, axis_linear_y_, required);
+  axis_angular_z_ = 2;
+  readParam(pnh_, "config/axis_angular_z", axis_angular_z_, axis_angular_z_, required);
+  button_kinematic_mode_ = 7;
+  readParam(pnh_, "config/button_kinematic_mode", button_kinematic_mode_, button_kinematic_mode_, required);
+  button_speed_up_ = 3;
+  readParam(pnh_, "config/button_speed_up", button_speed_up_, button_speed_up_, required);
+  button_speed_down_ = 1;
+  readParam(pnh_, "config/button_speed_down", button_speed_down_, button_speed_down_, required);
+  max_linear_speed_ = 1.5;
+  readParam(pnh_, "max_linear_speed", max_linear_speed_, max_linear_speed_, required);
+  max_angular_speed_ = 3.0;
+  readParam(pnh_, "max_angular_speed", max_angular_speed_, max_angular_speed_, required);
+  cmd_topic_vel_ = "cmd_vel";
+  readParam(pnh_, "cmd_topic_vel", cmd_topic_vel_, cmd_topic_vel_, required);
+  // if not set, then ackermann mode cannot be used
+  wheel_base_ = 0;
+  readParam(pnh_, "wheel_base", wheel_base_, wheel_base_);
+
+  // Publishers
+  ackermann_pub_ = nh_.advertise<ackermann_msgs::AckermannDrive>(cmd_topic_vel_, 10);
+  pad_status_pub_ = pnh_.advertise<robotnik_pad_msgs::MovementStatus>("status", 10);
+
+  // initialize variables
+  current_velocity_level_ = 0.1;
+  velocity_level_step_ = 0.1;
+  max_velocity_level_ = 1.0;
+  min_velocity_level_ = 0.1;
+  cmd_ackermann_ = ackermann_msgs::AckermannDrive();
+  movement_status_msg_ = robotnik_pad_msgs::MovementStatus();
+  kinematic_mode_ = KinematicModes::Ackermann;
+}
+
+void PadPluginAckermannMovement::execute(std::vector<Button>& buttons, std::vector<float>& axes)
+{
+  if (buttons[button_dead_man_].isPressed())
+  {
+    if (buttons[button_speed_down_].isReleased())
+    {
+      current_velocity_level_ = std::max(min_velocity_level_, current_velocity_level_ - velocity_level_step_);
+      ROS_INFO("PadPluginAckermannMovement::execute: speed down -> velocity level = %.1f%%", current_velocity_level_ * 100.0);
+    }
+    else if (buttons[button_speed_up_].isReleased())
+    {
+      current_velocity_level_ = std::min(max_velocity_level_, current_velocity_level_ + velocity_level_step_);
+      ROS_INFO("PadPluginAckermannMovement::execute: speed up -> velocity level = %.1f%%", current_velocity_level_ * 100.0);
+    }
+
+    /*if (buttons[button_kinematic_mode_].isReleased())
+    {
+      if (kinematic_mode_ == KinematicModes::Differential)
+      {
+        kinematic_mode_ = KinematicModes::Omnidirectional;
+      }
+      else if (kinematic_mode_ == KinematicModes::Omnidirectional)
+      {
+        if (wheel_base_ == 0)  // not set, ackermann mode cannot be selected
+        {
+          kinematic_mode_ = KinematicModes::Differential;
+        }
+        else
+        {
+          kinematic_mode_ = KinematicModes::Ackermann;
+        }
+      }
+      else if (kinematic_mode_ == KinematicModes::Ackermann)
+      {
+        kinematic_mode_ = KinematicModes::Differential;
+      }
+    }*/
+
+    cmd_ackermann_.linear.x = current_velocity_level_ * max_linear_speed_ * axes[axis_linear_x_];
+    if (kinematic_mode_ == KinematicModes::Ackermann)
+    {
+      cmd_ackermann_.angular.z = current_velocity_level_ * max_linear_speed_ * axes[axis_angular_x_]
+      cmd_ackermann_.linear.x = current_velocity_level_ * max_linear_speed_ * axes[axis_linear_x_]
+    }
+    else
+    {
+      cmd_ackermann_.angular.z = current_velocity_level_ * max_angular_speed_ * axes[axis_angular_z_];
+    }
+
+    if (kinematic_mode_ == KinematicModes::Omnidirectional)
+    {
+      cmd_ackermann_.linear.y = current_velocity_level_ * max_linear_speed_ * axes[axis_linear_y_];
+    }
+    else
+    {
+      cmd_ackermann_.linear.y = 0.0;
+    }
+
+    ackermann_pub_.publish(cmd_ackermann_);
+  }
+  else if (buttons[button_dead_man_].isReleased())
+  {
+    cmd_ackermann_.linear.x = 0.0;
+    cmd_ackermann_.linear.y = 0.0;
+    cmd_ackermann_.angular.z = 0.0;
+
+    ackermann_pub_.publish(cmd_ackermann_);
+  }
+
+  movement_status_msg_.velocity_level = current_velocity_level_ * 100;
+  movement_status_msg_.kinematic_mode = kinematicModeToStr(kinematic_mode_);
+  pad_status_pub_.publish(movement_status_msg_);
+}
+
+std::string PadPluginAckermannMovement::kinematicModeToStr(int kinematic_mode)
+{
+  switch (kinematic_mode)
+  {
+    case KinematicModes::Differential:
+      return "differential";
+    case KinematicModes::Omnidirectional:
+      return "omni";
+    case KinematicModes::Ackermann:
+      return "ackermann";
+    default:
+      return "unknown";
+  }
+}
+}  // namespace pad_plugins

--- a/robotnik_pad_plugins/src/ackermann_movement_plugin.cpp
+++ b/robotnik_pad_plugins/src/ackermann_movement_plugin.cpp
@@ -92,33 +92,15 @@ void PadPluginAckermannMovement::execute(std::vector<Button>& buttons, std::vect
       }
     }*/
 
-    cmd_ackermann_.linear.x = current_velocity_level_ * max_linear_speed_ * axes[axis_linear_x_];
-    if (kinematic_mode_ == KinematicModes::Ackermann)
-    {
-      cmd_ackermann_.angular.z = current_velocity_level_ * max_linear_speed_ * axes[axis_angular_x_]
-      cmd_ackermann_.linear.x = current_velocity_level_ * max_linear_speed_ * axes[axis_linear_x_]
-    }
-    else
-    {
-      cmd_ackermann_.angular.z = current_velocity_level_ * max_angular_speed_ * axes[axis_angular_z_];
-    }
-
-    if (kinematic_mode_ == KinematicModes::Omnidirectional)
-    {
-      cmd_ackermann_.linear.y = current_velocity_level_ * max_linear_speed_ * axes[axis_linear_y_];
-    }
-    else
-    {
-      cmd_ackermann_.linear.y = 0.0;
-    }
-
+    cmd_ackermann_.speed = current_velocity_level_ * max_linear_speed_ * axes[axis_linear_x_];
+    cmd_ackermann_.steering_angle = current_velocity_level_ * max_angular_speed_ * axes[axis_angular_x_]
+    
     ackermann_pub_.publish(cmd_ackermann_);
   }
   else if (buttons[button_dead_man_].isReleased())
   {
-    cmd_ackermann_.linear.x = 0.0;
-    cmd_ackermann_.linear.y = 0.0;
-    cmd_ackermann_.angular.z = 0.0;
+    cmd_ackermann_.speed = 0.0;
+    cmd_ackermann_.steering_angle = 0.0;
 
     ackermann_pub_.publish(cmd_ackermann_);
   }
@@ -132,10 +114,6 @@ std::string PadPluginAckermannMovement::kinematicModeToStr(int kinematic_mode)
 {
   switch (kinematic_mode)
   {
-    case KinematicModes::Differential:
-      return "differential";
-    case KinematicModes::Omnidirectional:
-      return "omni";
     case KinematicModes::Ackermann:
       return "ackermann";
     default:

--- a/robotnik_pad_plugins/src/generic_pad_plugins.cpp
+++ b/robotnik_pad_plugins/src/generic_pad_plugins.cpp
@@ -3,6 +3,8 @@
 #include <robotnik_pad/generic_pad_plugin.h>
 #include <robotnik_pad_plugins/movement_plugin.h>
 #include <robotnik_pad_plugins/elevator_plugin.h>
+#include <robotnik_pad_plugins/ackermann_movement_plugin.h>
 
 PLUGINLIB_EXPORT_CLASS(pad_plugins::PadPluginMovement, pad_plugins::GenericPadPlugin);
 PLUGINLIB_EXPORT_CLASS(pad_plugins::PadPluginElevator, pad_plugins::GenericPadPlugin);
+PLUGINLIB_EXPORT_CLASS(pad_plugins::PadPluginAckermannMovement, pad_plugins::GenericPadPlugin);

--- a/robotnik_pad_plugins/src/movement_plugin.cpp
+++ b/robotnik_pad_plugins/src/movement_plugin.cpp
@@ -47,7 +47,7 @@ void PadPluginMovement::initialize(const ros::NodeHandle& nh, const std::string&
   min_velocity_level_ = 0.1;
   cmd_twist_ = geometry_msgs::Twist();
   movement_status_msg_ = robotnik_pad_msgs::MovementStatus();
-  kinematic_mode_ = Differential;
+  kinematic_mode_ = KinematicModes::Differential;
 }
 
 void PadPluginMovement::execute(std::vector<Button>& buttons, std::vector<float>& axes)
@@ -67,20 +67,20 @@ void PadPluginMovement::execute(std::vector<Button>& buttons, std::vector<float>
 
     if (buttons[button_kinematic_mode_].isReleased())
     {
-      if (kinematic_mode_ == Differential)
+      if (kinematic_mode_ == KinematicModes::Differential)
       {
-        kinematic_mode_ = Omnidirectional;
+        kinematic_mode_ = KinematicModes::Omnidirectional;
       }
-      else if (kinematic_mode_ == Omnidirectional)
+      else if (kinematic_mode_ == KinematicModes::Omnidirectional)
       {
-        kinematic_mode_ = Differential;
+        kinematic_mode_ = KinematicModes::Differential;
       }
     }
 
     cmd_twist_.linear.x = current_velocity_level_ * max_linear_speed_ * axes[axis_linear_x_];
     cmd_twist_.angular.z = current_velocity_level_ * max_angular_speed_ * axes[axis_angular_z_];
 
-    if (kinematic_mode_ == Omnidirectional)
+    if (kinematic_mode_ == KinematicModes::Omnidirectional)
     {
       cmd_twist_.linear.y = current_velocity_level_ * max_linear_speed_ * axes[axis_linear_y_];
     }
@@ -109,9 +109,9 @@ std::string PadPluginMovement::kinematicModeToStr(int kinematic_mode)
 {
   switch (kinematic_mode)
   {
-    case Omnidirectional:
+    case KinematicModes::Omnidirectional:
       return "omni";
-    case Differential:
+    case KinematicModes::Differential:
       return "differential";
     default:
       return "Unknown";

--- a/robotnik_pad_plugins/src/movement_plugin.cpp
+++ b/robotnik_pad_plugins/src/movement_plugin.cpp
@@ -96,6 +96,7 @@ void PadPluginMovement::execute(std::vector<Button>& buttons, std::vector<float>
     {
       cmd_twist_.angular.z = current_velocity_level_ * max_linear_speed_ * axes[axis_linear_x_] *
                              std::sin(axes[axis_angular_z_] * (M_PI / 2.0)) / wheel_base_;
+      cmd_twist_.linear.x = current_velocity_level_ * max_linear_speed_ * axes[axis_linear_x_] * std::cos(axes[axis_angular_z_] * (M_PI / 2.0));
     }
     else
     {


### PR DESCRIPTION
Adds ackermman mode to pad.

Two ways:
- movement plugin: new kinematic mode along with differential and omni. Uses right joystick as steering reference, which is converted using wheelbase to linear/angular.
- ackermann plugin: publishes an ackermann message