### PR TITLE
FIX: Memory leaks

### DIFF
--- a/robotnik_pad/src/robotnik_pad.cpp
+++ b/robotnik_pad/src/robotnik_pad.cpp
@@ -16,11 +16,15 @@ int RobotnikPad::rosSetup()
 
   joy_sub_ = nh_.subscribe<sensor_msgs::Joy>(joy_topic_, 1, &RobotnikPad::joyCb, this);
   addTopicsHealth(&joy_sub_, joy_topic_, joy_timeout_);
+
+  return rcomponent::OK;
 }
 
 int RobotnikPad::rosShutdown()
 {
   RComponent::rosShutdown();
+
+  return rcomponent::OK;
 }
 
 void RobotnikPad::rosReadParams()
@@ -47,6 +51,7 @@ void RobotnikPad::rosReadParams()
 
 int RobotnikPad::setup()
 {
+  return rcomponent::OK;
 }
 
 void RobotnikPad::rosPublish()


### PR DESCRIPTION
Some memory leaks appear when the node is launched in noetic, making the node crash.
Errors are caused by a lack of return instruction in non-void functions.