### PR TITLE
Add elevator_action_plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .*vscode
+_codeql_detected_source_root

--- a/robotnik_pad_plugins/CMakeLists.txt
+++ b/robotnik_pad_plugins/CMakeLists.txt
@@ -12,13 +12,14 @@ find_package(catkin REQUIRED COMPONENTS
   pluginlib
   robotnik_pad
   robotnik_pad_msgs
+  actionlib
 )
 
 
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES robotnik_pad_plugins
-  CATKIN_DEPENDS roscpp pluginlib robotnik_pad robotnik_pad_msgs
+  CATKIN_DEPENDS roscpp pluginlib robotnik_pad robotnik_pad_msgs actionlib
 #  DEPENDS system_lib
 )
 
@@ -36,6 +37,7 @@ add_library(robotnik_pad_plugins
   src/poi_plugin.cpp
   src/ptz_plugin.cpp
   src/blkarc_plugin.cpp
+  src/elevator_action_plugin.cpp
 )
 
 add_dependencies(robotnik_pad_plugins ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})

--- a/robotnik_pad_plugins/include/robotnik_pad_plugins/elevator_action_plugin.h
+++ b/robotnik_pad_plugins/include/robotnik_pad_plugins/elevator_action_plugin.h
@@ -1,0 +1,38 @@
+#ifndef PAD_PLUGIN_ELEVATOR_ACTION_H_
+#define PAD_PLUGIN_ELEVATOR_ACTION_H_
+
+#include <robotnik_msgs/ElevatorAction.h>
+#include <robotnik_msgs/SetElevatorAction.h>
+#include <robotnik_msgs/SetElevatorActionGoal.h>
+#include <robotnik_msgs/SetElevatorGoal.h>
+#include <robotnik_msgs/SetElevatorResult.h>
+#include <robotnik_pad/generic_pad_plugin.h>
+#include <actionlib/client/simple_action_client.h>
+#include <actionlib/client/simple_client_goal_state.h>
+
+namespace pad_plugins
+{
+class PadPluginElevatorAction : public GenericPadPlugin
+{
+public:
+  PadPluginElevatorAction();
+  ~PadPluginElevatorAction();
+
+  virtual void initialize(const ros::NodeHandle &nh, const std::string &plugin_ns);
+  virtual void execute(const std::vector<Button> &buttons, std::vector<float> &axes);
+
+protected:
+  int button_dead_man_;
+  double axis_elevator_;
+  bool elevator_is_running_;
+  bool stop_elevator_;
+  bool stop_elevator_dead_man_;
+
+  std::string elevator_action_ns_;
+  std::shared_ptr<actionlib::SimpleActionClient<robotnik_msgs::SetElevatorAction>> elevator_action_client_;
+
+  bool sendGoal(const int action);
+  void actionDoneCb(const actionlib::SimpleClientGoalState& state,  const robotnik_msgs::SetElevatorResultConstPtr& result);
+};
+}; // namespace pad_plugins
+#endif  // PAD_PLUGIN_ELEVATOR_ACTION_H_

--- a/robotnik_pad_plugins/include/robotnik_pad_plugins/elevator_plugin.h
+++ b/robotnik_pad_plugins/include/robotnik_pad_plugins/elevator_plugin.h
@@ -20,6 +20,7 @@ protected:
   double axis_elevator_;
   bool elevator_is_running_;
   bool stop_elevator_;
+  bool stop_elevator_dead_man_;
 
   std::string elevator_service_name_;
   ros::ServiceClient set_elevator_client_;

--- a/robotnik_pad_plugins/package.xml
+++ b/robotnik_pad_plugins/package.xml
@@ -28,7 +28,6 @@
   <exec_depend>actionlib</exec_depend>
 
 
-
   <!-- The export tag contains other, unspecified, tags -->
   <export>
     <!-- Other tools can request additional information be placed here -->

--- a/robotnik_pad_plugins/package.xml
+++ b/robotnik_pad_plugins/package.xml
@@ -18,12 +18,14 @@
   <build_depend>pluginlib</build_depend>
   <build_depend>robotnik_pad</build_depend>
   <build_depend>robotnik_pad_msgs</build_depend>
+  <build_depend>actionlib</build_depend>
 
   <build_export_depend>roscpp</build_export_depend>
   <exec_depend>roscpp</exec_depend>
   <exec_depend>pluginlib</exec_depend>
   <exec_depend>robotnik_pad</exec_depend>
   <exec_depend>robotnik_pad_msgs</exec_depend>
+
 
 
   <!-- The export tag contains other, unspecified, tags -->

--- a/robotnik_pad_plugins/package.xml
+++ b/robotnik_pad_plugins/package.xml
@@ -25,6 +25,7 @@
   <exec_depend>pluginlib</exec_depend>
   <exec_depend>robotnik_pad</exec_depend>
   <exec_depend>robotnik_pad_msgs</exec_depend>
+  <exec_depend>actionlib</exec_depend>
 
 
 

--- a/robotnik_pad_plugins/robotnik_pad_pluginlib.xml
+++ b/robotnik_pad_plugins/robotnik_pad_pluginlib.xml
@@ -20,4 +20,7 @@
     <class name="robotnik_pad_plugins/BlkArc" type="pad_plugins::PadPluginBlkArc" base_class_type="pad_plugins::GenericPadPlugin">
         <description>This is the BLK ARC plugin.</description>
     </class>
+    <class name="robotnik_pad_plugins/ElevatorAction" type="pad_plugins::PadPluginElevatorAction" base_class_type="pad_plugins::GenericPadPlugin">
+        <description>This is the Pad elevator action plugin.</description>
+    </class>
 </library>

--- a/robotnik_pad_plugins/src/elevator_action_plugin.cpp
+++ b/robotnik_pad_plugins/src/elevator_action_plugin.cpp
@@ -22,7 +22,7 @@ void PadPluginElevatorAction::initialize(const ros::NodeHandle& nh, const std::s
   readParam(pnh_, "elevator_action_ns", elevator_action_ns_, elevator_action_ns_, required);
   readParam(pnh_, "stop_elevator", stop_elevator_, false, not_required);
   readParam(pnh_, "stop_elevator_dead_man", stop_elevator_dead_man_, false, not_required);
-  // Service client
+  // Actionlib action client
   elevator_action_client_ = std::make_shared
       <actionlib::SimpleActionClient<robotnik_msgs::SetElevatorAction>>(nh_, elevator_action_ns_, true);
 

--- a/robotnik_pad_plugins/src/elevator_action_plugin.cpp
+++ b/robotnik_pad_plugins/src/elevator_action_plugin.cpp
@@ -50,7 +50,7 @@ void PadPluginElevatorAction::execute(const std::vector<Button>& buttons, std::v
 
     if (stop_elevator_)
     {
-      if (axes[axis_elevator_] > -0.1 && axes[axis_elevator_] < 0.1 && elevator_is_running_ == true)
+      if (axes[axis_elevator_] > -0.1 && axes[axis_elevator_] < 0.1 && elevator_is_running_)
       {
         elevator_is_running_ = !sendGoal(robotnik_msgs::ElevatorAction::STOP);
       }

--- a/robotnik_pad_plugins/src/elevator_action_plugin.cpp
+++ b/robotnik_pad_plugins/src/elevator_action_plugin.cpp
@@ -1,0 +1,92 @@
+#include <robotnik_pad_plugins/elevator_action_plugin.h>
+
+namespace pad_plugins
+{
+PadPluginElevatorAction::PadPluginElevatorAction()
+{
+}
+
+PadPluginElevatorAction::~PadPluginElevatorAction()
+{
+}
+
+void PadPluginElevatorAction::initialize(const ros::NodeHandle& nh, const std::string& plugin_ns)
+{
+  bool required = true;
+  bool not_required = false;
+
+  pnh_ = ros::NodeHandle(nh, plugin_ns);
+
+  readParam(pnh_, "config/deadman", button_dead_man_, button_dead_man_, required);
+  readParam(pnh_, "config/axis_elevator", axis_elevator_, axis_elevator_, required);
+  readParam(pnh_, "elevator_action_ns", elevator_action_ns_, elevator_action_ns_, required);
+  readParam(pnh_, "stop_elevator", stop_elevator_, false, not_required);
+  readParam(pnh_, "stop_elevator_dead_man", stop_elevator_dead_man_, false, not_required);
+  // Service client
+  elevator_action_client_ = std::make_shared
+      <actionlib::SimpleActionClient<robotnik_msgs::SetElevatorAction>>(nh_, elevator_action_ns_, true);
+
+  elevator_is_running_ = false;
+}
+
+void PadPluginElevatorAction::execute(const std::vector<Button>& buttons, std::vector<float>& axes)
+{
+  if (buttons[button_dead_man_].isPressed())
+  {
+    if (axes[axis_elevator_] > 0.95)
+    {
+      if (!elevator_is_running_)
+      {
+        elevator_is_running_ = sendGoal(robotnik_msgs::ElevatorAction::RAISE);
+      }
+    }
+    if (axes[axis_elevator_] < -0.95)
+    {
+      if (!elevator_is_running_)
+      {
+        elevator_is_running_ = sendGoal(robotnik_msgs::ElevatorAction::LOWER);
+      }
+    }
+
+    if (stop_elevator_)
+    {
+      if (axes[axis_elevator_] > -0.1 && axes[axis_elevator_] < 0.1 && elevator_is_running_ == true)
+      {
+        elevator_is_running_ = !sendGoal(robotnik_msgs::ElevatorAction::STOP);
+      }
+    }
+
+  }
+  else if (buttons[button_dead_man_].isReleased())
+  {
+    if (stop_elevator_dead_man_ && elevator_is_running_)
+    {
+      elevator_is_running_ = !sendGoal(robotnik_msgs::ElevatorAction::STOP);
+    }
+  }
+}
+
+void PadPluginElevatorAction::actionDoneCb(const actionlib::SimpleClientGoalState& state,  const robotnik_msgs::SetElevatorResultConstPtr& result)
+{
+  elevator_is_running_ = false;
+}
+
+bool PadPluginElevatorAction::sendGoal(const int action)
+{
+  robotnik_msgs::SetElevatorGoal elevator_goal;
+  elevator_goal.action.action = action;
+  ROS_INFO_NAMED("PadPluginElevatorAction", "PadPluginElevatorAction::execute: %d", action);
+  elevator_action_client_->sendGoal(elevator_goal,
+                                  boost::bind(&PadPluginElevatorAction::actionDoneCb, this, _1, _2));
+  auto state = elevator_action_client_->getState();
+  if (!(state == actionlib::SimpleClientGoalState::PENDING ||
+  state == actionlib::SimpleClientGoalState::ACTIVE))
+  {
+    ROS_ERROR_NAMED("PadPluginElevatorAction", "PadPluginElevatorAction::execute: Goal was not accepted. Current state: %s", state.toString().c_str());
+    return false;
+  }
+  return true;
+}
+
+
+}  // namespace pad_plugins

--- a/robotnik_pad_plugins/src/elevator_plugin.cpp
+++ b/robotnik_pad_plugins/src/elevator_plugin.cpp
@@ -21,7 +21,7 @@ void PadPluginElevator::initialize(const ros::NodeHandle& nh, const std::string&
   readParam(pnh_, "config/axis_elevator", axis_elevator_, axis_elevator_, required);
   readParam(pnh_, "elevator_service_name", elevator_service_name_, elevator_service_name_, required);
   readParam(pnh_, "stop_elevator", stop_elevator_, false, not_required);
-
+  readParam(pnh_, "stop_elevator_dead_man", stop_elevator_dead_man_, false, not_required);
   // Service client
   set_elevator_client_ = nh_.serviceClient<robotnik_msgs::SetElevator>(elevator_service_name_);
 
@@ -34,40 +34,54 @@ void PadPluginElevator::execute(const std::vector<Button>& buttons, std::vector<
   {
     if (axes[axis_elevator_] > 0.95)
     {
-      robotnik_msgs::SetElevator elevator_msg_srv;
-      elevator_msg_srv.request.action.action = robotnik_msgs::ElevatorAction::RAISE;
-      ROS_INFO_NAMED("PadPluginElevator", "PadPluginElevator::execute: Raising...");
-      elevator_is_running_ = true;
-      if (set_elevator_client_.call(elevator_msg_srv) != true || elevator_msg_srv.response.ret != true)
+      if (!elevator_is_running_)
       {
-        ROS_ERROR_NAMED("PadPluginElevator", "PadPluginElevator::execute: Error raising");
+        robotnik_msgs::SetElevator elevator_msg_srv;
+        elevator_msg_srv.request.action.action = robotnik_msgs::ElevatorAction::RAISE;
+        ROS_INFO_NAMED("PadPluginElevator", "PadPluginElevator::execute: Raising...");
+        if (set_elevator_client_.call(elevator_msg_srv) != true || elevator_msg_srv.response.ret != true)
+        {
+          ROS_ERROR_NAMED("PadPluginElevator", "PadPluginElevator::execute: Error raising");
+        }
+        else
+        { 
+          elevator_is_running_ = true;
+        }
       }
     }
     if (axes[axis_elevator_] < -0.95)
     {
-      robotnik_msgs::SetElevator elevator_msg_srv;
-      elevator_msg_srv.request.action.action = robotnik_msgs::ElevatorAction::LOWER;
-      elevator_is_running_ = true;
-      ROS_INFO_NAMED("PadPluginElevator", "PadPluginElevator::execute: Lowering...");
-
-      if (set_elevator_client_.call(elevator_msg_srv) != true || elevator_msg_srv.response.ret != true)
+      if (!elevator_is_running_)
       {
-        ROS_ERROR_NAMED("PadPluginElevator", "PadPluginElevator::execute: Error lowering");
+        robotnik_msgs::SetElevator elevator_msg_srv;
+        elevator_msg_srv.request.action.action = robotnik_msgs::ElevatorAction::LOWER;
+        ROS_INFO_NAMED("PadPluginElevator", "PadPluginElevator::execute: Lowering...");
+        if (set_elevator_client_.call(elevator_msg_srv) != true || elevator_msg_srv.response.ret != true)
+        {
+          ROS_ERROR_NAMED("PadPluginElevator", "PadPluginElevator::execute: Error lowering");
+        }
+        else
+        {
+          elevator_is_running_ = true;
+        }
       }
     }
 
-    if (stop_elevator_==true){
+    if (stop_elevator_){
 
       if (axes[axis_elevator_] > -0.1 && axes[axis_elevator_] < 0.1 && elevator_is_running_ == true)
       {
         robotnik_msgs::SetElevator elevator_msg_srv;
         elevator_msg_srv.request.action.action = robotnik_msgs::ElevatorAction::STOP;
-        elevator_is_running_ = false;
         ROS_INFO_NAMED("PadPluginElevator", "PadPluginElevator::execute: Stoping...");
 
         if (set_elevator_client_.call(elevator_msg_srv) != true || elevator_msg_srv.response.ret != true)
         {
           ROS_ERROR_NAMED("PadPluginElevator", "PadPluginElevator::execute: Error stoping");
+        }
+        else
+        {
+          elevator_is_running_ = false;
         }
       }
     }
@@ -75,6 +89,21 @@ void PadPluginElevator::execute(const std::vector<Button>& buttons, std::vector<
   }
   else if (buttons[button_dead_man_].isReleased())
   {
+    if (stop_elevator_dead_man_ && elevator_is_running_)
+    {
+      robotnik_msgs::SetElevator elevator_msg_srv;
+      elevator_msg_srv.request.action.action = robotnik_msgs::ElevatorAction::STOP;
+      ROS_INFO_NAMED("PadPluginElevator", "PadPluginElevator::execute: Stoping...");
+
+      if (set_elevator_client_.call(elevator_msg_srv) != true || elevator_msg_srv.response.ret != true)
+      {
+        ROS_ERROR_NAMED("PadPluginElevator", "PadPluginElevator::execute: Error stoping");
+      }
+      else
+      {
+        elevator_is_running_ = false;
+      }
+    }
   }
 }
 

--- a/robotnik_pad_plugins/src/generic_pad_plugins.cpp
+++ b/robotnik_pad_plugins/src/generic_pad_plugins.cpp
@@ -8,6 +8,7 @@
 #include <robotnik_pad_plugins/poi_plugin.h>
 #include <robotnik_pad_plugins/ptz_plugin.h>
 #include <robotnik_pad_plugins/blkarc_plugin.h>
+#include <robotnik_pad_plugins/elevator_action_plugin.h>
 
 PLUGINLIB_EXPORT_CLASS(pad_plugins::PadPluginMovement, pad_plugins::GenericPadPlugin);
 PLUGINLIB_EXPORT_CLASS(pad_plugins::PadPluginSafetyMovement, pad_plugins::GenericPadPlugin);
@@ -16,3 +17,4 @@ PLUGINLIB_EXPORT_CLASS(pad_plugins::PadPluginAckermannMovement, pad_plugins::Gen
 PLUGINLIB_EXPORT_CLASS(pad_plugins::PadPluginPoi, pad_plugins::GenericPadPlugin);
 PLUGINLIB_EXPORT_CLASS(pad_plugins::PadPluginPtz, pad_plugins::GenericPadPlugin);
 PLUGINLIB_EXPORT_CLASS(pad_plugins::PadPluginBlkArc, pad_plugins::GenericPadPlugin);
+PLUGINLIB_EXPORT_CLASS(pad_plugins::PadPluginElevatorAction, pad_plugins::GenericPadPlugin);


### PR DESCRIPTION
This pull request adds a new elevator action pad plugin to the `robotnik_pad_plugins` package, enabling joystick control of elevator actions via ROS actionlib. The main changes include the implementation of the elevator action plugin, integration with build and package configuration files, and plugin registration.

**Elevator action plugin implementation:**
* Added new source file `src/elevator_action_plugin.cpp` and header `include/robotnik_pad_plugins/elevator_action_plugin.h` implementing `PadPluginElevatorAction`, which sends elevator commands (raise, lower, stop) using actionlib based on joystick input. [[1]](diffhunk://#diff-a26dabfbb62ad4052012c87ba0de460fc72a8cae60594fcd1c1782d628d7b3aaR1-R92) [[2]](diffhunk://#diff-d8f086cdd32382480ee7a673f668e70bce81e23c97aefa06c3b230e7f89a4aebR1-R38)

**Build and package configuration:**
* Updated `CMakeLists.txt` to include `actionlib` as a dependency and add the new plugin source file to the build. [[1]](diffhunk://#diff-4d44235d2a9da56d5740dd24f5edfa201b1b76ca9b5ac277a2255a4ff9ce60e3R15-R22) [[2]](diffhunk://#diff-4d44235d2a9da56d5740dd24f5edfa201b1b76ca9b5ac277a2255a4ff9ce60e3R40)
* Updated `package.xml` to declare `actionlib` as a build and exec dependency.

**Plugin registration:**
* Registered the new plugin in `robotnik_pad_pluginlib.xml` and exported it using `PLUGINLIB_EXPORT_CLASS` in `generic_pad_plugins.cpp`. [[1]](diffhunk://#diff-2e7802a195f42037a5eaa5c8d83dfb0c372ad9eec0d5032852f621369708ce84R23-R25) [[2]](diffhunk://#diff-7c3d0d68f71f396309678bdce6855dde304cf4285c1e06abb9243872bb5fc446R11) [[3]](diffhunk://#diff-7c3d0d68f71f396309678bdce6855dde304cf4285c1e06abb9243872bb5fc446R20)